### PR TITLE
chore: use PAT token for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           fetch-depth: 0
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
           npx --yes \
             -p semantic-release \


### PR DESCRIPTION
## Summary
- Switches the release workflow from the default `GITHUB_TOKEN` to `RELEASE_PLEASE_TOKEN` (a PAT) for both the checkout step and semantic-release
- Required because branch protection rules now require PRs for pushes to `main`, which `GITHUB_TOKEN` cannot bypass but a PAT from an admin user can

## Test plan
- [ ] Add `RELEASE_PLEASE_TOKEN` secret to the repository
- [ ] Merge this PR and verify the next release pipeline completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)